### PR TITLE
Add HACS badge to installation section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,7 @@
 - Тесты `pytest`, эмулирующие облачное API и покрывающие ключевую бизнес-логику.
 
 ## Установка
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=ZxKill&repository=https%3A%2F%2Fgithub.com%2Fzxkill%2Fhomeassistant-is)
 1. Установите Home Assistant 2023.5+.
 2. Через [HACS](https://hacs.xyz/) добавьте репозиторий как **Custom Repository** (категория *Integration*) либо вручную скопируйте `custom_components/intersvyaz` в каталог `config/custom_components`.
 3. Перезапустите Home Assistant, затем добавьте интеграцию **Intersvyaz Doorphone** в разделе «Настройки → Устройства и службы».


### PR DESCRIPTION
## Summary
- add HACS badge link to README installation section for quick repository access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ca9ace20832197ab12afbe14f9dd