### PR TITLE
Fix CRM authorization by sending mobile bearer

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,8 +157,13 @@ async def api_server(aiohttp_server):
     async def handle_crm_auth(request: web.Request) -> web.Response:
         state["crm_auth_calls"] += 1
         payload = await request.json()
+        # CRM сервис ожидает увидеть мобильный токен как в теле запроса,
+        # так и в заголовке Authorization, повторяя реальное API.
         if payload.get("token") != "primary-token":
             return web.json_response({"message": "bad token"}, status=401)
+        auth_header = request.headers.get("Authorization")
+        if auth_header != "Bearer primary-token":
+            return web.json_response({"message": "missing bearer"}, status=401)
         return web.json_response(
             {
                 "USER_ID": 3000001,


### PR DESCRIPTION
## Summary
- send the mobile JWT as a bearer header when requesting a CRM token to match the upstream API expectations
- update CRM header builder to support both mobile and CRM JWTs with detailed inline comments and logging context
- extend CRM auth test double to validate the new Authorization header contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d72b4e84832191672e9afb55f08c