### PR TITLE
2.0.16: improve real-world face recognition

### DIFF
--- a/custom_components/intersvyaz/manifest.json
+++ b/custom_components/intersvyaz/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "numpy==2.3.2"
   ],
-  "version": "2.0.15"
+  "version": "2.0.16"
 }

--- a/custom_components/intersvyaz/recognition/__init__.py
+++ b/custom_components/intersvyaz/recognition/__init__.py
@@ -1,10 +1,7 @@
 """Локальный изолированный движок распознавания лиц Intersvyaz."""
 
-from .engine import (
-    FaceRecognitionResult,
-    OpenCvFaceRecognitionEngine,
-    PortableFaceRecognitionEngine,
-)
+from .engine import FaceRecognitionResult
+from .engine_v2 import OpenCvFaceRecognitionEngine, PortableFaceRecognitionEngine
 
 __all__ = [
     "FaceRecognitionResult",

--- a/custom_components/intersvyaz/recognition/engine_v2.py
+++ b/custom_components/intersvyaz/recognition/engine_v2.py
@@ -1,0 +1,140 @@
+"""Адаптер portable face worker v2 с расширенной безопасной диагностикой.
+
+Descriptor format и engine_id намеренно остаются ``portable_face_v1``:
+существующие сохранённые лица продолжают работать без миграции и повторной
+загрузки фотографий. Меняется только стратегия сравнения runtime-кадра:
+worker_v2 проверяет несколько близких вариантов crop лица.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .engine import FaceRecognitionResult
+from .engine import PortableFaceRecognitionEngine as _BasePortableFaceRecognitionEngine
+
+_LOGGER = logging.getLogger("custom_components.intersvyaz.recognition")
+
+
+class PortableFaceRecognitionEngine(_BasePortableFaceRecognitionEngine):
+    """Portable engine v2, совместимый с descriptor portable_face_v1."""
+
+    # Не меняем ID: формат 128-мерного descriptor остался тем же.
+    engine_id = "portable_face_v1"
+
+    def recognize(
+        self,
+        image_bytes: bytes,
+        known_faces: Sequence[tuple[str, Sequence[float]]],
+        threshold: float,
+    ) -> FaceRecognitionResult:
+        """Распознать лица и записать полезную диагностику результата сравнения."""
+
+        if not image_bytes:
+            raise HomeAssistantError("Пустое изображение невозможно обработать")
+
+        response = self._rpc(
+            {
+                "command": "recognize",
+                "image": __import__("base64").b64encode(image_bytes).decode("ascii"),
+                "known_faces": [
+                    {"name": str(name), "encoding": [float(value) for value in encoding]}
+                    for name, encoding in known_faces
+                ],
+                "threshold": float(threshold),
+            }
+        )
+
+        try:
+            faces_detected = max(int(response.get("faces_detected", 0)), 0)
+        except (TypeError, ValueError):
+            faces_detected = 0
+
+        matched_name = response.get("matched_name")
+        if not isinstance(matched_name, str) or not matched_name:
+            matched_name = None
+
+        distance_raw = response.get("distance")
+        try:
+            distance = float(distance_raw) if distance_raw is not None else None
+        except (TypeError, ValueError):
+            distance = None
+
+        try:
+            variants_tested = max(int(response.get("variants_tested", 0)), 0)
+        except (TypeError, ValueError):
+            variants_tested = 0
+
+        _LOGGER.info(
+            "[FACE][COMPARE] known=%s faces=%s variants=%s distance=%s threshold=%.3f "
+            "matched=%s auto_open_safe=%s",
+            len(known_faces),
+            faces_detected,
+            variants_tested,
+            f"{distance:.4f}" if distance is not None else "none",
+            float(threshold),
+            bool(matched_name),
+            bool(response.get("auto_open_safe", False)),
+        )
+
+        return FaceRecognitionResult(
+            faces_detected=faces_detected,
+            matched_name=matched_name,
+            distance=distance,
+            auto_open_safe=bool(response.get("auto_open_safe", False)),
+        )
+
+    def _ensure_worker_locked(self) -> subprocess.Popen[str]:
+        """Запустить worker v2 с теми же изоляцией и протоколом, что у базового engine."""
+
+        process = self._process
+        if process is not None and process.poll() is None:
+            return process
+
+        if process is not None:
+            self._process = None
+
+        worker_path = Path(__file__).with_name("worker_v2.py")
+        if not worker_path.is_file():
+            raise HomeAssistantError(
+                "Файл recognition worker v2 отсутствует в установленной интеграции"
+            )
+
+        _LOGGER.info(
+            "[FACE][WORKER_START] version=multicrop_v2 python=%s engine=%s",
+            sys.executable,
+            self.engine_id,
+        )
+        try:
+            process = subprocess.Popen(
+                [sys.executable, "-u", str(worker_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                bufsize=1,
+                close_fds=True,
+            )
+        except OSError as err:
+            raise HomeAssistantError(
+                f"Не удалось запустить локальный recognition worker v2: {err}"
+            ) from err
+
+        self._process = process
+        return process
+
+
+# Совместимость со старым публичным именем интеграции.
+OpenCvFaceRecognitionEngine = PortableFaceRecognitionEngine
+
+__all__ = [
+    "FaceRecognitionResult",
+    "PortableFaceRecognitionEngine",
+    "OpenCvFaceRecognitionEngine",
+]

--- a/custom_components/intersvyaz/recognition/worker_v2.py
+++ b/custom_components/intersvyaz/recognition/worker_v2.py
@@ -1,0 +1,197 @@
+"""Improved portable recognition worker for real doorphone camera frames.
+
+This module reuses the proven detector/descriptor from ``worker.py`` but makes
+matching more tolerant to imperfect face crops. A doorphone snapshot rarely
+frames a face exactly like an enrollment photo: the head may be slightly higher,
+lower, closer or farther from the camera. Instead of weakening the identity
+threshold, we compare several nearby crops and keep the best distance.
+
+The strict threshold and auto-open safety rules remain unchanged.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import worker as legacy
+
+_ENGINE_ID = legacy._ENGINE_ID
+
+
+def _variant_boxes(
+    box: tuple[int, int, int, int],
+    image_width: int,
+    image_height: int,
+) -> list[tuple[int, int, int, int]]:
+    """Return small crop variations around one detector box.
+
+    Variants intentionally stay conservative. They compensate detector jitter
+    without searching arbitrary parts of the frame, which would increase false
+    matches.
+    """
+
+    left, top, right, bottom = box
+    width = max(right - left, 1)
+    height = max(bottom - top, 1)
+    center_x = (left + right) / 2.0
+    center_y = (top + bottom) / 2.0
+
+    variants: list[tuple[float, float]] = [
+        (1.00, 0.00),
+        (1.12, 0.00),
+        (1.24, 0.00),
+        (0.92, 0.00),
+        (1.12, -0.08),
+        (1.12, 0.08),
+    ]
+    result: list[tuple[int, int, int, int]] = []
+
+    for scale, vertical_shift in variants:
+        new_width = width * scale
+        new_height = height * scale
+        shifted_y = center_y + height * vertical_shift
+        candidate = (
+            max(0, int(round(center_x - new_width / 2.0))),
+            max(0, int(round(shifted_y - new_height / 2.0))),
+            min(image_width, int(round(center_x + new_width / 2.0))),
+            min(image_height, int(round(shifted_y + new_height / 2.0))),
+        )
+        if candidate[2] - candidate[0] < 16 or candidate[3] - candidate[1] < 16:
+            continue
+        if candidate not in result:
+            result.append(candidate)
+
+    return result or [box]
+
+
+def _recognize(request: dict[str, Any]) -> dict[str, object]:
+    """Recognize using several nearby crops while preserving strict threshold."""
+
+    image = legacy._decode_image(request.get("image"))
+    candidates = legacy._detect_candidates(image)
+    known_faces = legacy._parse_known_faces(request.get("known_faces"))
+
+    if not candidates:
+        return {
+            "faces_detected": 0,
+            "matched_name": None,
+            "distance": None,
+            "engine": _ENGINE_ID,
+            "auto_open_safe": False,
+            "variants_tested": 0,
+        }
+
+    if not known_faces:
+        return {
+            "faces_detected": len(candidates),
+            "matched_name": None,
+            "distance": None,
+            "engine": _ENGINE_ID,
+            "auto_open_safe": False,
+            "variants_tested": 0,
+        }
+
+    try:
+        threshold = float(request.get("threshold", 0.30))
+    except (TypeError, ValueError):
+        threshold = 0.30
+    threshold = max(0.10, min(0.55, threshold))
+
+    best_name: str | None = None
+    best_distance: float | None = None
+    best_candidate = None
+    variants_tested = 0
+
+    for candidate in candidates:
+        for variant_box in _variant_boxes(candidate.box, image.width, image.height):
+            variants_tested += 1
+            candidate_encoding = legacy._descriptor(
+                legacy._normalized_crop(image, variant_box)
+            )
+            for name, known_encoding in known_faces:
+                current_distance = legacy._distance(known_encoding, candidate_encoding)
+                if best_distance is None or current_distance < best_distance:
+                    best_distance = current_distance
+                    best_name = name
+                    best_candidate = candidate
+
+    if best_distance is None or best_distance > threshold:
+        return {
+            "faces_detected": len(candidates),
+            "matched_name": None,
+            "distance": best_distance,
+            "engine": _ENGINE_ID,
+            "auto_open_safe": False,
+            "variants_tested": variants_tested,
+        }
+
+    auto_open_safe = bool(
+        best_candidate is not None
+        and best_candidate.source == "skin"
+        and best_candidate.skin_density >= 0.28
+        and len(candidates) == 1
+    )
+    return {
+        "faces_detected": len(candidates),
+        "matched_name": best_name,
+        "distance": best_distance,
+        "engine": _ENGINE_ID,
+        "auto_open_safe": auto_open_safe,
+        "variants_tested": variants_tested,
+    }
+
+
+def _handle(request: dict[str, Any]) -> dict[str, object]:
+    command = request.get("command")
+    if command == "recognize":
+        return _recognize(request)
+    if command == "healthcheck":
+        payload = legacy._handle(request)
+        payload["matcher"] = "portable_multicrop_v2"
+        payload["crop_variants"] = 6
+        return payload
+    return legacy._handle(request)
+
+
+def main() -> int:
+    """Run the same JSONL protocol as the original isolated worker."""
+
+    for raw_line in sys.stdin:
+        request_id: object = None
+        try:
+            request = json.loads(raw_line)
+            if not isinstance(request, dict):
+                raise ValueError("Запрос worker должен быть JSON-объектом")
+            request_id = request.get("request_id")
+
+            if request.get("command") == "shutdown":
+                print(
+                    json.dumps(
+                        {"ok": True, "request_id": request_id},
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                    flush=True,
+                )
+                return 0
+
+            payload = _handle(request)
+            response = {"ok": True, "request_id": request_id, **payload}
+        except Exception as err:
+            response = {
+                "ok": False,
+                "request_id": request_id,
+                "error_code": err.__class__.__name__,
+                "error": str(err),
+            }
+
+        print(
+            json.dumps(response, ensure_ascii=False, separators=(",", ":")),
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,7 @@ import json
 def test_manifest_is_stable_v2(component_root):
     manifest = json.loads((component_root / "manifest.json").read_text())
     assert manifest["domain"] == "intersvyaz"
-    assert manifest["version"] == "2.0.15"
+    assert manifest["version"] == "2.0.16"
     assert manifest["config_flow"] is True
     assert manifest["integration_type"] == "hub"
     assert manifest["requirements"] == ["numpy==2.3.2"]

--- a/tests/test_recognition_multicrop.py
+++ b/tests/test_recognition_multicrop.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _worker_rpc(worker: Path, request: dict) -> dict:
+    process = subprocess.Popen(
+        [sys.executable, "-u", str(worker)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    try:
+        assert process.stdin is not None
+        assert process.stdout is not None
+        process.stdin.write(json.dumps(request) + "\n")
+        process.stdin.flush()
+        response = json.loads(process.stdout.readline())
+        process.stdin.write(json.dumps({"command": "shutdown", "request_id": -1}) + "\n")
+        process.stdin.flush()
+        process.wait(timeout=5)
+        return response
+    finally:
+        if process.poll() is None:
+            process.kill()
+
+
+def _load_worker_v2(component_root: Path, monkeypatch: pytest.MonkeyPatch):
+    recognition_root = component_root / "recognition"
+    monkeypatch.syspath_prepend(str(recognition_root))
+    path = recognition_root / "worker_v2.py"
+    spec = importlib.util.spec_from_file_location("intersvyaz_worker_v2_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_multicrop_variants_are_conservative_and_bounded(component_root, monkeypatch):
+    worker = _load_worker_v2(component_root, monkeypatch)
+
+    variants = worker._variant_boxes((100, 80, 180, 180), 320, 240)
+
+    assert len(variants) == 6
+    assert (100, 80, 180, 180) in variants
+    assert len(set(variants)) == len(variants)
+    assert all(0 <= left < right <= 320 for left, _top, right, _bottom in variants)
+    assert all(0 <= top < bottom <= 240 for _left, top, _right, bottom in variants)
+
+
+def test_multicrop_worker_healthcheck(component_root):
+    if importlib.util.find_spec("numpy") is None or importlib.util.find_spec("PIL") is None:
+        pytest.skip("Pillow/NumPy not installed in unit-test environment")
+
+    response = _worker_rpc(
+        component_root / "recognition" / "worker_v2.py",
+        {"command": "healthcheck", "request_id": 1},
+    )
+
+    assert response["ok"] is True
+    assert response["engine"] == "portable_face_v1"
+    assert response["matcher"] == "portable_multicrop_v2"
+    assert response["crop_variants"] == 6
+
+
+def test_multicrop_keeps_strict_threshold_and_existing_descriptors(component_root):
+    worker = (component_root / "recognition" / "worker_v2.py").read_text()
+    engine = (component_root / "recognition" / "engine_v2.py").read_text()
+    package = (component_root / "recognition" / "__init__.py").read_text()
+
+    assert "threshold = max(0.10, min(0.55, threshold))" in worker
+    assert 'engine_id = "portable_face_v1"' in engine
+    assert "[FACE][COMPARE]" in engine
+    assert "from .engine_v2 import" in package


### PR DESCRIPTION
## Что исправлено

Распознавание лиц в portable-движке было слишком чувствительно к кадрированию. Эталонная фотография и реальный snapshot домофона обычно содержат лицо с немного разным масштабом и вертикальным положением, поэтому даже корректно найденное лицо часто уходило в `unknown_person`.

### Изменения
- добавлен изолированный `worker_v2.py` с консервативным multi-crop сравнением;
- для каждого найденного лица проверяются 6 близких вариантов рамки (масштаб/небольшое вертикальное смещение);
- строгий порог совпадения **не ослаблен**;
- правила `auto_open_safe`, streak и cooldown **не изменены**;
- `engine_id` остаётся `portable_face_v1`, поэтому сохранённые descriptors совместимы и повторно загружать лица не нужно;
- добавлен INFO-лог `[FACE][COMPARE]` с `known`, `faces`, `variants`, `distance`, `threshold`, `matched`, `auto_open_safe`;
- никаких изображений, токенов или персональных идентификаторов в диагностический лог не пишется;
- добавлены тесты multi-crop и healthcheck;
- версия поднята до `2.0.16`.

## Зачем не повышать threshold

Простое увеличение threshold повысило бы вероятность ложного распознавания, особенно опасного при включённом автооткрытии. Multi-crop уменьшает ошибку кадрирования, сохраняя прежнюю строгость идентификации.

## Совместимость

Новых зависимостей нет: по-прежнему только Pillow из HA + `numpy==2.3.2`.